### PR TITLE
php: add PHP_INI_DIR variable to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ apk add --no-cache php7.3-dev gcc g++
 pecl install {extension-name}
 ```
 
+### PHP ini settings
+
+To configure extra [php.ini](https://www.php.net/manual/en/ini.php): settings,
+create application specific `php.ini` and copy the file into docker image:
+
+
+```ini
+# php.ini
+memory_limit = 512M
+```
+
+```Dockerfile
+FROM phpearth/php:7.3-nginx
+
+COPY php.ini $PHP_INI_DIR/conf.d/my-app.ini
+```
+
 #### Missing extension?
 
 In case you'd need an additional extension in the PHP.earth repository, [open an issue](https://github.com/phpearth/docker-php/issues).

--- a/docker/7.0-apache.Dockerfile
+++ b/docker/7.0-apache.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.0, Apache, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.0-apache.Dockerfile
+++ b/docker/7.0-apache.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.0 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.0 \
         php7.0-phar \
         php7.0-bcmath \
         php7.0-calendar \
@@ -53,7 +54,8 @@ ENV \
         curl \
         ca-certificates \
         runit \
-        apache2"
+        apache2 \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0-cgi.Dockerfile
+++ b/docker/7.0-cgi.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.0 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.0 \
         php7.0-phar \
         php7.0-bcmath \
         php7.0-calendar \
@@ -52,7 +53,8 @@ ENV \
         php7.0-cgi \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0-cgi.Dockerfile
+++ b/docker/7.0-cgi.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CGI 7.0, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.0-cli.Dockerfile
+++ b/docker/7.0-cli.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.0 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.0 \
         php7.0-phar \
         php7.0-bcmath \
         php7.0-calendar \
@@ -50,7 +51,8 @@ ENV \
         php7.0-json \
         php7.0-posix \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0-cli.Dockerfile
+++ b/docker/7.0-cli.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.0, additional PHP extensions, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.0-lighttpd.Dockerfile
+++ b/docker/7.0-lighttpd.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.0, Lighttpd, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.0-lighttpd.Dockerfile
+++ b/docker/7.0-lighttpd.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="lighttpd \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        lighttpd \
         php7.0 \
         php7.0-phar \
         php7.0-bcmath \
@@ -53,7 +54,8 @@ ENV \
         php7.0-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0-litespeed.Dockerfile
+++ b/docker/7.0-litespeed.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="curl \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        curl \
         ca-certificates \
         runit \
         php7.0 \
@@ -53,7 +54,8 @@ ENV \
         php7.0-json \
         php7.0-posix \
         php7.0-litespeed \
-        litespeed"
+        litespeed \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0-litespeed.Dockerfile
+++ b/docker/7.0-litespeed.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.0, OpenLiteSpeed, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.0-nginx.Dockerfile
+++ b/docker/7.0-nginx.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.0, Nginx, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.0-nginx.Dockerfile
+++ b/docker/7.0-nginx.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="nginx \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        nginx \
         nginx-mod-http-headers-more \
         php7.0 \
         php7.0-phar \
@@ -54,7 +55,8 @@ ENV \
         php7.0-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0.Dockerfile
+++ b/docker/7.0.Dockerfile
@@ -15,13 +15,15 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.0
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.0 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.0 \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.0.Dockerfile
+++ b/docker/7.0.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.0, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.0
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1-apache.Dockerfile
+++ b/docker/7.1-apache.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.1 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.1 \
         php7.1-phar \
         php7.1-bcmath \
         php7.1-calendar \
@@ -53,7 +54,8 @@ ENV \
         curl \
         ca-certificates \
         runit \
-        apache2"
+        apache2 \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1-apache.Dockerfile
+++ b/docker/7.1-apache.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.1, Apache, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1-cgi.Dockerfile
+++ b/docker/7.1-cgi.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.1 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.1 \
         php7.1-phar \
         php7.1-bcmath \
         php7.1-calendar \
@@ -52,7 +53,8 @@ ENV \
         php7.1-cgi \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1-cgi.Dockerfile
+++ b/docker/7.1-cgi.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CGI 7.1, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1-cli.Dockerfile
+++ b/docker/7.1-cli.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.1, additional PHP extensions, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1-cli.Dockerfile
+++ b/docker/7.1-cli.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.1 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.1 \
         php7.1-phar \
         php7.1-bcmath \
         php7.1-calendar \
@@ -50,7 +51,8 @@ ENV \
         php7.1-json \
         php7.1-posix \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1-lighttpd.Dockerfile
+++ b/docker/7.1-lighttpd.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="lighttpd \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        lighttpd \
         php7.1 \
         php7.1-phar \
         php7.1-bcmath \
@@ -53,7 +54,8 @@ ENV \
         php7.1-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1-lighttpd.Dockerfile
+++ b/docker/7.1-lighttpd.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.1, Lighttpd, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1-litespeed.Dockerfile
+++ b/docker/7.1-litespeed.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.1, OpenLiteSpeed, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1-litespeed.Dockerfile
+++ b/docker/7.1-litespeed.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="curl \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        curl \
         ca-certificates \
         runit \
         php7.1 \
@@ -53,7 +54,8 @@ ENV \
         php7.1-json \
         php7.1-posix \
         php7.1-litespeed \
-        litespeed"
+        litespeed \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1-nginx.Dockerfile
+++ b/docker/7.1-nginx.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="nginx \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        nginx \
         nginx-mod-http-headers-more \
         php7.1 \
         php7.1-phar \
@@ -54,7 +55,8 @@ ENV \
         php7.1-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1-nginx.Dockerfile
+++ b/docker/7.1-nginx.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.1, Nginx, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.1.Dockerfile
+++ b/docker/7.1.Dockerfile
@@ -15,13 +15,15 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.1
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.1 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.1 \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.1.Dockerfile
+++ b/docker/7.1.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.1, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.1
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2-apache.Dockerfile
+++ b/docker/7.2-apache.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.2, Apache, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2-apache.Dockerfile
+++ b/docker/7.2-apache.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.2 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.2 \
         php7.2-phar \
         php7.2-bcmath \
         php7.2-calendar \
@@ -53,7 +54,8 @@ ENV \
         curl \
         ca-certificates \
         runit \
-        apache2"
+        apache2 \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.2-cgi.Dockerfile
+++ b/docker/7.2-cgi.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.2 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.2 \
         php7.2-phar \
         php7.2-bcmath \
         php7.2-calendar \
@@ -52,7 +53,8 @@ ENV \
         php7.2-cgi \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.2-cgi.Dockerfile
+++ b/docker/7.2-cgi.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CGI 7.2, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2-cli.Dockerfile
+++ b/docker/7.2-cli.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.2 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.2 \
         php7.2-phar \
         php7.2-bcmath \
         php7.2-calendar \
@@ -50,7 +51,8 @@ ENV \
         php7.2-json \
         php7.2-posix \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.2-cli.Dockerfile
+++ b/docker/7.2-cli.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.2, additional PHP extensions, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2-lighttpd.Dockerfile
+++ b/docker/7.2-lighttpd.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="lighttpd \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        lighttpd \
         php7.2 \
         php7.2-phar \
         php7.2-bcmath \
@@ -53,7 +54,8 @@ ENV \
         php7.2-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.2-lighttpd.Dockerfile
+++ b/docker/7.2-lighttpd.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.2, Lighttpd, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2-litespeed.Dockerfile
+++ b/docker/7.2-litespeed.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="curl \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        curl \
         ca-certificates \
         runit \
         php7.2 \
@@ -53,7 +54,8 @@ ENV \
         php7.2-json \
         php7.2-posix \
         php7.2-litespeed \
-        litespeed"
+        litespeed \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.2-litespeed.Dockerfile
+++ b/docker/7.2-litespeed.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.2, OpenLiteSpeed, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2-nginx.Dockerfile
+++ b/docker/7.2-nginx.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="nginx \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        nginx \
         nginx-mod-http-headers-more \
         php7.2 \
         php7.2-phar \
@@ -54,7 +55,8 @@ ENV \
         php7.2-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.2-nginx.Dockerfile
+++ b/docker/7.2-nginx.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.2, Nginx, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2.Dockerfile
+++ b/docker/7.2.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.2, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.2
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.2.Dockerfile
+++ b/docker/7.2.Dockerfile
@@ -15,13 +15,15 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.2
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.2 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.2 \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3-apache.Dockerfile
+++ b/docker/7.3-apache.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.3 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.3 \
         php7.3-phar \
         php7.3-bcmath \
         php7.3-calendar \
@@ -53,7 +54,8 @@ ENV \
         curl \
         ca-certificates \
         runit \
-        apache2"
+        apache2 \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3-apache.Dockerfile
+++ b/docker/7.3-apache.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.3, Apache, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.3-cgi.Dockerfile
+++ b/docker/7.3-cgi.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CGI 7.3, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.3-cgi.Dockerfile
+++ b/docker/7.3-cgi.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.3 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.3 \
         php7.3-phar \
         php7.3-bcmath \
         php7.3-calendar \
@@ -52,7 +53,8 @@ ENV \
         php7.3-cgi \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3-cli.Dockerfile
+++ b/docker/7.3-cli.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.3 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.3 \
         php7.3-phar \
         php7.3-bcmath \
         php7.3-calendar \
@@ -50,7 +51,8 @@ ENV \
         php7.3-json \
         php7.3-posix \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3-cli.Dockerfile
+++ b/docker/7.3-cli.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.3, additional PHP extensions, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.3-lighttpd.Dockerfile
+++ b/docker/7.3-lighttpd.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="lighttpd \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        lighttpd \
         php7.3 \
         php7.3-phar \
         php7.3-bcmath \
@@ -53,7 +54,8 @@ ENV \
         php7.3-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3-lighttpd.Dockerfile
+++ b/docker/7.3-lighttpd.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.3, Lighttpd, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.3-litespeed.Dockerfile
+++ b/docker/7.3-litespeed.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="curl \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        curl \
         ca-certificates \
         runit \
         php7.3 \
@@ -53,7 +54,8 @@ ENV \
         php7.3-json \
         php7.3-posix \
         php7.3-litespeed \
-        litespeed"
+        litespeed \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3-litespeed.Dockerfile
+++ b/docker/7.3-litespeed.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.3, OpenLiteSpeed, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.3-nginx.Dockerfile
+++ b/docker/7.3-nginx.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.3, Nginx, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.3-nginx.Dockerfile
+++ b/docker/7.3-nginx.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="nginx \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        nginx \
         nginx-mod-http-headers-more \
         php7.3 \
         php7.3-phar \
@@ -54,7 +55,8 @@ ENV \
         php7.3-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3.Dockerfile
+++ b/docker/7.3.Dockerfile
@@ -15,13 +15,15 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.3
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.3 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.3 \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.3.Dockerfile
+++ b/docker/7.3.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.3, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.3
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4-apache.Dockerfile
+++ b/docker/7.4-apache.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.4, Apache, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4-apache.Dockerfile
+++ b/docker/7.4-apache.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.4 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.4 \
         php7.4-phar \
         php7.4-bcmath \
         php7.4-calendar \
@@ -53,7 +54,8 @@ ENV \
         curl \
         ca-certificates \
         runit \
-        apache2"
+        apache2 \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4-cgi.Dockerfile
+++ b/docker/7.4-cgi.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CGI 7.4, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4-cgi.Dockerfile
+++ b/docker/7.4-cgi.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.4 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.4 \
         php7.4-phar \
         php7.4-bcmath \
         php7.4-calendar \
@@ -52,7 +53,8 @@ ENV \
         php7.4-cgi \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4-cli.Dockerfile
+++ b/docker/7.4-cli.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.4 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.4 \
         php7.4-phar \
         php7.4-bcmath \
         php7.4-calendar \
@@ -50,7 +51,8 @@ ENV \
         php7.4-json \
         php7.4-posix \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4-cli.Dockerfile
+++ b/docker/7.4-cli.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.4, additional PHP extensions, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4-lighttpd.Dockerfile
+++ b/docker/7.4-lighttpd.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.4, Lighttpd, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4-lighttpd.Dockerfile
+++ b/docker/7.4-lighttpd.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="lighttpd \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        lighttpd \
         php7.4 \
         php7.4-phar \
         php7.4-bcmath \
@@ -53,7 +54,8 @@ ENV \
         php7.4-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4-litespeed.Dockerfile
+++ b/docker/7.4-litespeed.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="curl \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        curl \
         ca-certificates \
         runit \
         php7.4 \
@@ -53,7 +54,8 @@ ENV \
         php7.4-json \
         php7.4-posix \
         php7.4-litespeed \
-        litespeed"
+        litespeed \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4-litespeed.Dockerfile
+++ b/docker/7.4-litespeed.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.4, OpenLiteSpeed, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4-nginx.Dockerfile
+++ b/docker/7.4-nginx.Dockerfile
@@ -15,11 +15,12 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="nginx \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        nginx \
         nginx-mod-http-headers-more \
         php7.4 \
         php7.4-phar \
@@ -54,7 +55,8 @@ ENV \
         php7.4-fpm \
         curl \
         ca-certificates \
-        runit"
+        runit \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4-nginx.Dockerfile
+++ b/docker/7.4-nginx.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP 7.4, Nginx, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \

--- a/docker/7.4.Dockerfile
+++ b/docker/7.4.Dockerfile
@@ -15,13 +15,15 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 # PHP_INI_DIR to be symmetrical with official php docker image
 ENV PHP_INI_DIR /etc/php/7.4
 
-ENV \
-    # When using Composer, disable the warning about running commands as root/super user
-    COMPOSER_ALLOW_SUPERUSER=1 \
-    # Persistent runtime dependencies
-    DEPS="php7.4 \
+# When using Composer, disable the warning about running commands as root/super user
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+# Persistent runtime dependencies
+ARG DEPS="\
+        php7.4 \
         curl \
-        ca-certificates"
+        ca-certificates \
+"
 
 # PHP.earth Alpine repository for better developer experience
 ADD https://repos.php.earth/alpine/phpearth.rsa.pub /etc/apk/keys/phpearth.rsa.pub

--- a/docker/7.4.Dockerfile
+++ b/docker/7.4.Dockerfile
@@ -12,6 +12,9 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.description="Docker For PHP Developers - Docker image with PHP CLI 7.4, and Alpine" \
       org.label-schema.url="https://github.com/phpearth/docker-php"
 
+# PHP_INI_DIR to be symmetrical with official php docker image
+ENV PHP_INI_DIR /etc/php/7.4
+
 ENV \
     # When using Composer, disable the warning about running commands as root/super user
     COMPOSER_ALLOW_SUPERUSER=1 \


### PR DESCRIPTION
- remove `$DEPS` variable from the final image
- add `$PHP_INI_DIR` to be symmetrical with official php docker image

```
# this project
$ docker run --rm -it app:latest sh -c 'ls -ld $PHP_INI_DIR/conf.d'
drwxr-xr-x    2 root     root          4096 May 26 00:52 /etc/php/7.1/conf.d

# official docker php image
$ docker run --rm -it php sh -c 'ls -ld $PHP_INI_DIR/conf.d'
drwxr-sr-x 1 root staff 4096 May  8 02:36 /usr/local/etc/php/conf.d
```